### PR TITLE
Remove STAC Collections mention in schema, fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The fields in the table below can be used in these parts of STAC documents:
 | landsat:wrs_row             | string | WRS Row                                                                                                                                             |
 | landsat:cloud_cover_land    | number | Land Cloud Cover                                                                                                                                    |
 | landsat:correction          | string | Product Correction Level                                                                                                                            |
-| landsat:product_generated   | string | The dateime that the product (data) was generated, formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
+| landsat:product_generated   | string | The datetime that the product (data) was generated, formatted according to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6). |
 
 ### Additional Field Information
 

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -2,7 +2,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://stac-extensions.github.io/landsat/v2.0.0/schema.json",
     "title": "Landsat Extension",
-    "description": "Landsat Extension to STAC Items and STAC Collections.",
+    "description": "Landsat Extension to STAC Items.",
     "allOf": [
         {
             "type": "object",


### PR DESCRIPTION
- Remove mention of STAC Collections in the json schema description since it only applies to STAC Items.
- Fix typo in README.